### PR TITLE
Define `_USE_MATH_DEFINES` when targeting Windows

### DIFF
--- a/src/heuristics/maxcut/burer2002.cpp
+++ b/src/heuristics/maxcut/burer2002.cpp
@@ -1,3 +1,6 @@
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <string.h>
 #include <algorithm>


### PR DESCRIPTION
This is necessary in order to access the mathematical constants defined in `math.h`, as per Windows documentation:
<https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170>.

Spotted in https://github.com/JuliaPackaging/Yggdrasil/pull/5901