### PR TITLE
Include `limits` header file

### DIFF
--- a/src/heuristics/qubo/glover2010.cpp
+++ b/src/heuristics/qubo/glover2010.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <iostream>
 #include <vector>
+#include <limits>
 #include "heuristics/qubo/glover2010.h"
 #include "util/random.h"
 

--- a/src/heuristics/qubo/katayama2000.cpp
+++ b/src/heuristics/qubo/katayama2000.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include "heuristics/qubo/katayama2000.h"
 #include "util/random.h"
 

--- a/src/heuristics/qubo/merz2002.cpp
+++ b/src/heuristics/qubo/merz2002.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include "heuristics/qubo/merz2002.h"
 #include "util/random.h"
 

--- a/src/heuristics/qubo/merz2004.cpp
+++ b/src/heuristics/qubo/merz2004.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include "heuristics/qubo/merz2004.h"
 #include "util/random.h"
 


### PR DESCRIPTION
This header file is mandatory for using `std::numeric_limits`.  Not including it is simply an error (and newer versions of GCC make this error more apparent).

Spotted in https://github.com/JuliaPackaging/Yggdrasil/pull/5901.